### PR TITLE
Updated permissions for deployer

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,9 +30,6 @@ jobs:
           role-session-name: salmoncowDeployer
           aws-region: ${{ env.AWS_REGION }}
 
-      - name: Test AWS creds
-        run: aws sts get-caller-identity
-
       - name: Set up tfvars
         working-directory: ./src/terraform
         id: vars

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,8 +1,8 @@
 name: CI
 on:
   push:
-    branches:    
-      - main
+    # branches:    
+    #   - main
 
 env:
   AWS_REGION: us-east-1
@@ -29,6 +29,9 @@ jobs:
           role-to-assume: arn:aws:iam::678856875282:role/td001-dev-salmoncow-deployer-role
           role-session-name: salmoncowDeployer
           aws-region: ${{ env.AWS_REGION }}
+
+      - name: Test AWS creds
+        run: aws sts get-caller-identity
 
       - name: Set up tfvars
         working-directory: ./src/terraform

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,8 +1,8 @@
 name: CI
 on:
   push:
-    # branches:    
-    #   - main
+    branches:    
+      - main
 
 env:
   AWS_REGION: us-east-1

--- a/src/terraform/providers.tf
+++ b/src/terraform/providers.tf
@@ -4,5 +4,5 @@
 
 provider "aws" {
   region  = var.region
-  profile = "default"
+  profile = ""
 }

--- a/src/terraform/providers.tf
+++ b/src/terraform/providers.tf
@@ -4,5 +4,4 @@
 
 provider "aws" {
   region  = var.region
-  profile = ""
 }


### PR DESCRIPTION
Using the latest public S3 module introduced a permissions error:

```
│ Error: AccessDenied: Access Denied
│ 	status code: 403, request id: TMAWXQBBEMY2HJK6, host id: xsFPk9q/CNcZu4px3EBcQOOsUv5v4HUvGMsNGhzgB1tH8kjCCvmWaoh0YnvTUKntZARZjz3WsC0=
│ 
│   with module.s3_bucket_salmoncow_app.data.aws_canonical_user_id.this,
│   on .terraform/modules/s3_bucket_salmoncow_app/main.tf line 1, in data "aws_canonical_user_id" "this":
│    1: data "aws_canonical_user_id" "this" {}
```

This was fixed by adding this specific permission to the deployer role:

```
  statement {
    sid    = "salmoncowDepoloyerRoleS3ListAllBuckets"
    effect = "Allow"
    actions = ["s3:ListAllMyBuckets"]
    resources = ["*"]
  }
```